### PR TITLE
Add Github Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 1. [Create a new repo](https://github.com/new) and [clone it](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) on your local machine.
 
    > **Note:** You can't simply fork this repository because none of the commits will count toward the contribution graph.
-   [More info here](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-graphs-on-your-profile/why-are-my-contributions-not-showing-up-on-my-profile#issues-pull-requests-and-discussions).
+   > [More info here](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-graphs-on-your-profile/why-are-my-contributions-not-showing-up-on-my-profile#issues-pull-requests-and-discussions).
 
 2. Clone this project locally and copy/paste it's contents into the repo you just created.
 3. Run `npm i` in your terminal.
@@ -38,6 +38,17 @@ If you change your mind about these commits later, you can delete the repository
 Explore the [code](src/index.js)! It's tiny and there aren't many dependencies.
 
 It only scrapes publicly available data from existing GitHub contribution graphs. It does not have access to private commits or issues created. So I can promise that you will not get in trouble for syncing your personal and work GitHub graphs considering there isn't any private company code being exposed!
+
+## Using with Github Enterprise
+
+You'll need to set a few environmental variables
+
+```
+export GITHUB_DOMAIN=git.{YOURDOMAIN}.com
+export GITHUB_PERSONAL_ACCESS_TOKEN={a personal access token with the correct permissions to read users}
+export GITHUB_COOKIE={a cookie copied from an active browser session (this should work with pretty much all SSO implementations}
+npm run start
+```
 
 ## On Project's Future ✨
 

--- a/src/axios.js
+++ b/src/axios.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+// In the case of a GHE account, you'll need auth options. otherwise, no.
+const options =
+  process.env.GITHUB_PERSONAL_ACCESS_TOKEN && process.env.GITHUB_COOKIE
+    ? {
+        headers: {
+          Authorization: `bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+          Cookie: process.env.GITHUB_COOKIE,
+        },
+      }
+    : {};
+
+const instance = axios.create(options);
+
+export default instance;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
 import { parse } from "node-html-parser";
-import axios from "axios";
+import axios from "./axios.js";
 import fs from "fs";
 import shell from "shelljs";
 
 export default async (input) => {
+  //In the case of a GitHub enterprise account, the API is at a different location
+  const githubdomain = process.env.GITHUB_DOMAIN
+    ? process.env.GITHUB_DOMAIN
+    : "github.com";
+
   const res = await axios.get(
-    `https://github.com/users/${input.username}/contributions?tab=overview&from=${input.year}-12-01&to=${input.year}-12-31`
+    `https://${githubdomain}/users/${input.username}/contributions?tab=overview&from=${input.year}-12-01&to=${input.year}-12-31`
   );
 
   // Gathers all the squares from GitHub contribution graph.

--- a/src/interface.js
+++ b/src/interface.js
@@ -1,8 +1,12 @@
 import inquirer from "inquirer";
 import script from "./index.js";
-import axios from "axios";
+import axios from "./axios.js";
 
 console.log("\nHello there!\n");
+
+const githubapi = process.env.GITHUB_DOMAIN
+  ? process.env.GITHUB_DOMAIN + "/api/v3"
+  : "api.github.com";
 
 const questions = [
   {
@@ -12,7 +16,7 @@ const questions = [
       "Please enter GitHub nickname with which you'd like to sync contributions:",
     validate: (value) =>
       axios
-        .get(`https://api.github.com/users/${value}`)
+        .get(`https://${githubapi}/users/${value}`)
         .then(() => true)
         .catch(() => "Please enter an existing GitHub username."),
   },


### PR DESCRIPTION
Allows for environmental variables to be configured to access GitHub Enterprise
```
export GITHUB_DOMAIN=git.{YOURDOMAIN}.com
export GITHUB_PERSONAL_ACCESS_TOKEN={a personal access token with the correct permissions to read users}
export GITHUB_COOKIE={a cookie copied from an active browser session (this should work with pretty much all SSO implementations}
npm run start
```