### PR TITLE
Change imperative logic to list processing style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,20 +3,23 @@ import axios from "axios";
 import fs from "fs";
 import shell from "shelljs";
 
-function commits_for(contribution) {
+// Gathers needed git commands for bash to execute per provided contribution data.
+const getCommand = (contribution) => {
   return `GIT_AUTHOR_DATE=${contribution.date}T12:00:00 GIT_COMMITER_DATE=${contribution.date}T12:00:00 git commit --allow-empty -m "Rewriting History!" > /dev/null\n`.repeat(contribution.count)
 }
 
 export default async (input) => {
+  // Returns contribution graph html for a full selected year.
   const res = await axios.get(
     `https://github.com/users/${input.username}/contributions?tab=overview&from=${input.year}-12-01&to=${input.year}-12-31`
   );
 
-  // Gathers all the squares from GitHub contribution graph.
+  // Retrives needed data from the html, loops over green squares with 1+ contributions,
+  // and produces a multi-line string that can be run as a bash command.
   const script = parse(res.data).querySelectorAll("[data-count]")
     .map(el => { return {date: el.attributes["data-date"], count: parseInt(el.attributes["data-count"])}} )
     .filter(contribution => contribution.count > 0)
-    .map(contribution => commits_for(contribution))
+    .map(contribution => getCommand(contribution))
     .join("")
     .concat(
       "git pull origin main\n",

--- a/src/index.js
+++ b/src/index.js
@@ -3,29 +3,25 @@ import axios from "axios";
 import fs from "fs";
 import shell from "shelljs";
 
+function commits_for(contribution) {
+  return `GIT_AUTHOR_DATE=${contribution.date}T12:00:00 GIT_COMMITER_DATE=${contribution.date}T12:00:00 git commit --allow-empty -m "Rewriting History!" > /dev/null\n`.repeat(contribution.count)
+}
+
 export default async (input) => {
   const res = await axios.get(
     `https://github.com/users/${input.username}/contributions?tab=overview&from=${input.year}-12-01&to=${input.year}-12-31`
   );
 
   // Gathers all the squares from GitHub contribution graph.
-  const allSquares = parse(res.data).querySelectorAll("[data-count]");
-
-  const script = allSquares
-    .reduce((fullCommand, contribution) => {
-      const count = contribution._rawAttrs["data-count"];
-      const date = contribution._rawAttrs["data-date"];
-
-      // Only care about html elements of squares with 1+ contributions for that day.
-      if (count > 0) {
-        return (fullCommand +=
-          `GIT_AUTHOR_DATE=${date}T12:00:00 GIT_COMMITER_DATE=${date}T12:00:00 git commit --allow-empty -m "Rewriting History!" > /dev/null\n`.repeat(
-            count
-          ));
-      }
-      return fullCommand;
-    }, "#!/bin/bash \n")
-    .concat("", "git pull origin main\ngit push -f origin main");
+  const script = parse(res.data).querySelectorAll("[data-count]")
+    .map(el => { return {date: el.attributes["data-date"], count: parseInt(el.attributes["data-count"])}} )
+    .filter(contribution => contribution.count > 0)
+    .map(contribution => commits_for(contribution))
+    .join("")
+    .concat(
+      "git pull origin main\n",
+      "git push -f origin main"
+    );
 
   fs.writeFile("script.sh", script, () => {
     console.log("\nFile was created successfully.");


### PR DESCRIPTION
The code was already using `reduce` for list processing, but the content of that function was mostly imperative.
This PR applies list processing style to the bulk of the script generation.

It's purely a style thing, but I think one of the nicest thing about this style is that it captures the intent in a way that reads like a recipe.


* get the elements with data-count
* tidy them up into a "contribution object"
* keep contributions where the count is more than 0 (or, reject contributions without a count)
* convert the contributions into git commits
* join them together
* add on the commands to push to the repo
